### PR TITLE
fix: Replace mfa-enabled filter with auth-methods filter.

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/entraid_user.py
+++ b/tools/c7n_azure/c7n_azure/resources/entraid_user.py
@@ -25,7 +25,7 @@ class EntraIDUser(GraphResourceManager):
     Supports filtering by user properties, authentication methods, group memberships,
     and security settings. See Common EntraID Examples section for additional patterns.
 
-    Available filters: value, mfa-enabled, risk-level, last-sign-in, group-membership, password-age
+    Available filters: value, auth-methods, risk-level, last-sign-in, group-membership, password-age
     Available actions: disable, require-mfa
 
     Permissions: See Graph API Permissions Reference section.
@@ -210,9 +210,10 @@ class EntraIDUser(GraphResourceManager):
         except Exception:
             return 0
 
-    def check_user_mfa_status(self, user_id):
-        """Check if user has MFA enabled by querying authentication methods.
+    def get_user_auth_methods(self, user_id):
+        """Get user's authentication methods from Graph API.
 
+        Returns the full list of authentication methods for the user.
         Required permission: UserAuthenticationMethod.Read.All
         """
         try:
@@ -221,20 +222,7 @@ class EntraIDUser(GraphResourceManager):
             response = self.make_graph_request(endpoint)
 
             methods = response.get('value', [])
-
-            # Check for MFA-capable authentication methods
-            mfa_methods = [
-                '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod',
-                '#microsoft.graph.phoneAuthenticationMethod',
-                '#microsoft.graph.fido2AuthenticationMethod',
-                '#microsoft.graph.windowsHelloForBusinessAuthenticationMethod',
-                '#microsoft.graph.temporaryAccessPassAuthenticationMethod'
-            ]
-
-            # Check if user has any MFA methods configured
-            has_mfa = any(method.get('@odata.type') in mfa_methods for method in methods)
-
-            return has_mfa
+            return methods
 
         except requests.exceptions.RequestException as e:
             if "403" in str(e) or "Insufficient privileges" in str(e):
@@ -242,9 +230,9 @@ class EntraIDUser(GraphResourceManager):
                     f"Insufficient privileges to read authentication methods for user {user_id}. "
                     "Required permission: UserAuthenticationMethod.Read.All"
                 )
-                return None  # Unknown MFA status
+                return None  # Unknown auth methods
             else:
-                log.error(f"Error checking MFA status for user {user_id}: {e}")
+                log.error(f"Error getting authentication methods for user {user_id}: {e}")
                 return None
 
     def check_user_risk_level(self, user_id):
@@ -323,25 +311,39 @@ class EntraIDUser(GraphResourceManager):
                 return None
 
 
-@EntraIDUser.filter_registry.register('mfa-enabled')
-class MFAEnabledFilter(Filter):
-    """Filter users by MFA enablement status.
+@EntraIDUser.filter_registry.register('auth-methods')
+class AuthMethodsFilter(Filter):
+    """Filter users by authentication methods.
+
+    Returns users with their authentication methods populated in the
+    'c7n:AuthMethods' field for use with value filters or other processing.
 
     Requires: UserAuthenticationMethod.Read.All
 
     :example:
 
+    Get all users with their authentication methods:
+
     .. code-block:: yaml
 
         filters:
-          - type: mfa-enabled
-            value: false
+          - type: auth-methods
+
+    Then use with value filter to check specific auth method types:
+
+    .. code-block:: yaml
+
+        filters:
+          - type: auth-methods
+          - type: value
+            key: 'c7n:AuthMethods[*]."@odata.type"'
+            op: contains
+            value: '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
     """
 
-    schema = type_schema('mfa-enabled', value={'type': 'boolean'})
+    schema = type_schema('auth-methods')
 
     def process(self, resources, event=None):  # pylint: disable=unused-argument
-        mfa_enabled = self.data.get('value', True)
         filtered = []
 
         for resource in resources:
@@ -352,21 +354,21 @@ class MFAEnabledFilter(Filter):
                 )
                 continue
 
-            # Check actual MFA status via Graph API
-            has_mfa = self.manager.check_user_mfa_status(user_id)
+            # Get user's authentication methods from Graph API
+            auth_methods = self.manager.get_user_auth_methods(user_id)
 
-            if has_mfa is None:
-                # Unknown MFA status (permission error or API failure)
+            if auth_methods is None:
+                # Unknown auth methods (permission error or API failure)
                 # Skip this user to avoid false results
                 log.warning(
-                    f"Could not determine MFA status for user "
+                    f"Could not determine authentication methods for user "
                     f"{resource.get('displayName', user_id)}"
                 )
                 continue
 
-            if has_mfa == mfa_enabled:
-
-                filtered.append(resource)
+            # Add auth methods to user resource for filtering
+            resource['c7n:AuthMethods'] = auth_methods
+            filtered.append(resource)
 
         return filtered
 

--- a/tools/c7n_azure/c7n_azure/resources/entraid_user.py
+++ b/tools/c7n_azure/c7n_azure/resources/entraid_user.py
@@ -5,7 +5,7 @@ import logging
 import requests
 from datetime import datetime
 
-from c7n.filters import Filter
+from c7n.filters import Filter, ValueFilter
 from c7n.utils import local_session, type_schema
 from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.constants import MSGRAPH_RESOURCE_ID
@@ -312,49 +312,32 @@ class EntraIDUser(GraphResourceManager):
 
 
 @EntraIDUser.filter_registry.register('auth-methods')
-class AuthMethodsFilter(Filter):
+class AuthMethodsFilter(ValueFilter):
     """Filter users by authentication methods.
 
-    Returns users with their authentication methods populated in the
-    'c7n:AuthMethods' field for use with value filters or other processing.
+    Filters users based on their registered authentication methods.
 
     Requires: UserAuthenticationMethod.Read.All
 
     :example:
 
-    Get all users with their authentication methods:
-
     .. code-block:: yaml
 
         filters:
           - type: auth-methods
-
-    Then use with value filter to check specific auth method types:
-
-    .. code-block:: yaml
-
-        filters:
-          - type: auth-methods
-          - type: value
-            key: 'c7n:AuthMethods[*]."@odata.type"'
+            key: '[]."@odata.type"'
             op: contains
             value: '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
     """
 
-    schema = type_schema('auth-methods')
+    schema = type_schema('auth-methods', rinherit=ValueFilter.schema)
+    auth_methods_annotation_key = 'c7n:AuthMethods'
+    annotate = False
 
-    def process(self, resources, event=None):  # pylint: disable=unused-argument
-        filtered = []
-
-        for resource in resources:
-            user_id = resource.get('id') or resource.get('objectId')
-            if not user_id:
-                log.warning(
-                    f"Skipping user without ID: {resource.get('displayName', 'Unknown')}"
-                )
-                continue
-
+    def __call__(self, i):
+        if self.auth_methods_annotation_key not in i:
             # Get user's authentication methods from Graph API
+            user_id = i.get('id') or i.get('objectId')
             auth_methods = self.manager.get_user_auth_methods(user_id)
 
             if auth_methods is None:
@@ -362,15 +345,14 @@ class AuthMethodsFilter(Filter):
                 # Skip this user to avoid false results
                 log.warning(
                     f"Could not determine authentication methods for user "
-                    f"{resource.get('displayName', user_id)}"
+                    f"{i.get('displayName', user_id)}"
                 )
-                continue
+                auth_methods = []
 
             # Add auth methods to user resource for filtering
-            resource['c7n:AuthMethods'] = auth_methods
-            filtered.append(resource)
+            i[self.auth_methods_annotation_key] = auth_methods
 
-        return filtered
+        return super().__call__(i[self.auth_methods_annotation_key])
 
 
 @EntraIDUser.filter_registry.register('risk-level')

--- a/tools/c7n_azure/tests_azure/tests_resources/test_entraid.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_entraid.py
@@ -85,9 +85,9 @@ client.return_value = mock_client
         self.assertTrue(augmented[0]['c7n:IsHighPrivileged'])
         self.assertFalse(augmented[1]['c7n:IsHighPrivileged'])
 
-    @patch('c7n_azure.resources.entraid_user.EntraIDUser.check_user_mfa_status')
-    def test_mfa_enabled_filter(self, mock_mfa_check):
-        """Test MFA enabled filter with real Graph API implementation"""
+    @patch('c7n_azure.resources.entraid_user.EntraIDUser.get_user_auth_methods')
+    def test_auth_methods_filter(self, mock_auth_methods):
+        """Test authentication methods filter with real Graph API implementation"""
         users = [
             {
                 'id': 'user1',
@@ -106,34 +106,69 @@ client.return_value = mock_client
             }
         ]
 
-        # Mock MFA status: user1 has MFA, user2 doesn't, user3 unknown
-        def mock_mfa_side_effect(user_id):
+        # Mock authentication methods: user1 has multiple methods, user2 has one, user3 has none
+        def mock_auth_methods_side_effect(user_id):
             if user_id == 'user1':
-                return True
+                return [
+                    {
+                        '@odata.type': (
+                            '#microsoft.graph.'
+                            'microsoftAuthenticatorAuthenticationMethod'
+                        ),
+                        'id': 'method1-id',
+                        'displayName': 'Microsoft Authenticator'
+                    },
+                    {
+                        '@odata.type': '#microsoft.graph.phoneAuthenticationMethod',
+                        'id': 'method2-id',
+                        'phoneNumber': '+1555XXXX123',
+                        'phoneType': 'mobile'
+                    }
+                ]
             elif user_id == 'user2':
-                return False
+                return [
+                    {
+                        '@odata.type': '#microsoft.graph.phoneAuthenticationMethod',
+                        'id': 'method3-id',
+                        'phoneNumber': '+1555XXXX456',
+                        'phoneType': 'mobile'
+                    }
+                ]
             else:
-                return None  # Unknown status
+                return []  # No authentication methods
 
-        mock_mfa_check.side_effect = mock_mfa_side_effect
+        mock_auth_methods.side_effect = mock_auth_methods_side_effect
 
         policy = self.load_policy({
-            'name': 'test-mfa-filter',
+            'name': 'test-auth-methods-filter',
             'resource': 'azure.entraid-user',
             'filters': [
-                {'type': 'mfa-enabled', 'value': True}
+                {'type': 'auth-methods'},
+                {'type': 'value', 'key': 'c7n:AuthMethods', 'value': 'present'}
             ]
         })
 
         resource_mgr = policy.resource_manager
         filtered = resource_mgr.filter_resources(users)
 
-        # Only user1 has MFA enabled (user3 skipped due to unknown status)
-        self.assertEqual(len(filtered), 1)
-        self.assertEqual(filtered[0]['id'], 'user1')
+        # Should have 3 users with auth methods data enriched (including user with empty list)
+        self.assertEqual(len(filtered), 3)
 
-        # Verify the MFA check was called for each user
-        self.assertEqual(mock_mfa_check.call_count, 3)
+        # Check that users are enriched with auth methods data
+        for user in filtered:
+            self.assertIn('c7n:AuthMethods', user)
+
+        # Check actual auth methods content
+        user1 = next(u for u in filtered if u['id'] == 'user1')
+        user2 = next(u for u in filtered if u['id'] == 'user2')
+        user3 = next(u for u in filtered if u['id'] == 'user3')
+
+        self.assertEqual(len(user1['c7n:AuthMethods']), 2)  # User1 has 2 methods
+        self.assertEqual(len(user2['c7n:AuthMethods']), 1)  # User2 has 1 method
+        self.assertEqual(len(user3['c7n:AuthMethods']), 0)  # User3 has no methods
+
+        # Verify the auth methods check was called for each user
+        self.assertEqual(mock_auth_methods.call_count, 3)
 
     def test_last_signin_filter(self):
         """Test last sign-in filter"""

--- a/tools/c7n_azure/tests_azure/tests_resources/test_entraid.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_entraid.py
@@ -143,8 +143,7 @@ client.return_value = mock_client
             'name': 'test-auth-methods-filter',
             'resource': 'azure.entraid-user',
             'filters': [
-                {'type': 'auth-methods'},
-                {'type': 'value', 'key': 'c7n:AuthMethods', 'value': 'present'}
+                {'type': 'auth-methods', 'key': '[]."@odata.type"', 'value': 'not-null'}
             ]
         })
 
@@ -152,7 +151,7 @@ client.return_value = mock_client
         filtered = resource_mgr.filter_resources(users)
 
         # Should have 3 users with auth methods data enriched (including user with empty list)
-        self.assertEqual(len(filtered), 3)
+        self.assertEqual(len(filtered), 2)
 
         # Check that users are enriched with auth methods data
         for user in filtered:
@@ -161,11 +160,9 @@ client.return_value = mock_client
         # Check actual auth methods content
         user1 = next(u for u in filtered if u['id'] == 'user1')
         user2 = next(u for u in filtered if u['id'] == 'user2')
-        user3 = next(u for u in filtered if u['id'] == 'user3')
 
         self.assertEqual(len(user1['c7n:AuthMethods']), 2)  # User1 has 2 methods
         self.assertEqual(len(user2['c7n:AuthMethods']), 1)  # User2 has 1 method
-        self.assertEqual(len(user3['c7n:AuthMethods']), 0)  # User3 has no methods
 
         # Verify the auth methods check was called for each user
         self.assertEqual(mock_auth_methods.call_count, 3)

--- a/tools/c7n_azure/tests_azure/tests_resources/test_entraid_simple.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_entraid_simple.py
@@ -95,8 +95,8 @@ class EntraIDUserTest(unittest.TestCase):
         self.assertFalse(augmented[1]['c7n:IsHighPrivileged'])
 
     @patch('c7n_azure.resources.entraid_user.local_session')
-    def test_mfa_enabled_filter(self, mock_session):
-        """Test MFA enabled filter"""
+    def test_auth_methods_filter(self, mock_session):
+        """Test authentication methods filter"""
         # Mock the session and Graph API responses
         mock_client = Mock()
         mock_session.return_value.get_session_for_resource.return_value = mock_client
@@ -104,37 +104,62 @@ class EntraIDUserTest(unittest.TestCase):
         users = [
             {
                 'objectId': 'user1',
-                'strongAuthenticationDetail': {'methods': ['PhoneAuth']}
+                'id': 'user1'
             },
             {
                 'objectId': 'user2',
-                'strongAuthenticationDetail': {'methods': []}
+                'id': 'user2'
             },
             {
-                'objectId': 'user3'
+                'objectId': 'user3',
+                'id': 'user3'
             }
         ]
 
         policy_data = {
-            'name': 'test-mfa-filter',
+            'name': 'test-auth-methods-filter',
             'resource': 'azure.entraid-user',
             'filters': [
-                {'type': 'mfa-enabled', 'value': True}
+                {'type': 'auth-methods'}
             ]
         }
 
         policy = self.load_policy(policy_data)
         resource_mgr = policy.resource_manager
 
-        # Mock the Graph API responses for MFA status
+        # Mock the Graph API responses for authentication methods
         def mock_make_graph_request(endpoint):
             if 'user1/authentication/methods' in endpoint:
                 return {
-                    'value': [{
-
-                        '@odata.type':
-                        '#microsoft.graph.microsoftAuthenticatorAuthenticationMethod'
-                    }]
+                    'value': [
+                        {
+                            '@odata.type': (
+                                '#microsoft.graph.'
+                                'microsoftAuthenticatorAuthenticationMethod'
+                            ),
+                            'id': 'method1-id',
+                            'displayName': 'Microsoft Authenticator'
+                        },
+                        {
+                            '@odata.type': (
+                                '#microsoft.graph.phoneAuthenticationMethod'
+                            ),
+                            'id': 'method2-id',
+                            'phoneNumber': '+1555XXXX123',
+                            'phoneType': 'mobile'
+                        }
+                    ]
+                }
+            elif 'user2/authentication/methods' in endpoint:
+                return {
+                    'value': [
+                        {
+                            '@odata.type': '#microsoft.graph.phoneAuthenticationMethod',
+                            'id': 'method3-id',
+                            'phoneNumber': '+1555XXXX456',
+                            'phoneType': 'mobile'
+                        }
+                    ]
                 }
             else:
                 return {'value': []}
@@ -143,9 +168,20 @@ class EntraIDUserTest(unittest.TestCase):
 
         filtered = resource_mgr.filter_resources(users)
 
-        # Only user1 has MFA enabled
-        self.assertEqual(len(filtered), 1)
-        self.assertEqual(filtered[0]['objectId'], 'user1')
+        # Should have all 3 users - the filter enriches all users with auth methods data
+        self.assertEqual(len(filtered), 3)
+        self.assertIn('c7n:AuthMethods', filtered[0])
+        self.assertIn('c7n:AuthMethods', filtered[1])
+        self.assertIn('c7n:AuthMethods', filtered[2])
+
+        # Check that auth methods data is properly enriched
+        user1_methods = next(u for u in filtered if u['objectId'] == 'user1')['c7n:AuthMethods']
+        user2_methods = next(u for u in filtered if u['objectId'] == 'user2')['c7n:AuthMethods']
+        user3_methods = next(u for u in filtered if u['objectId'] == 'user3')['c7n:AuthMethods']
+
+        self.assertEqual(len(user1_methods), 2)  # User1 has 2 auth methods
+        self.assertEqual(len(user2_methods), 1)  # User2 has 1 auth method
+        self.assertEqual(len(user3_methods), 0)  # User3 has no auth methods
 
     def test_last_signin_filter(self):
         """Test last sign-in filter"""

--- a/tools/c7n_azure/tests_azure/tests_resources/test_entraid_simple.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_entraid_simple.py
@@ -120,7 +120,7 @@ class EntraIDUserTest(unittest.TestCase):
             'name': 'test-auth-methods-filter',
             'resource': 'azure.entraid-user',
             'filters': [
-                {'type': 'auth-methods'}
+                {'type': 'auth-methods', 'key': '[]."@odata.type"', 'value': 'not-null'}
             ]
         }
 
@@ -169,19 +169,16 @@ class EntraIDUserTest(unittest.TestCase):
         filtered = resource_mgr.filter_resources(users)
 
         # Should have all 3 users - the filter enriches all users with auth methods data
-        self.assertEqual(len(filtered), 3)
+        self.assertEqual(len(filtered), 2)
         self.assertIn('c7n:AuthMethods', filtered[0])
         self.assertIn('c7n:AuthMethods', filtered[1])
-        self.assertIn('c7n:AuthMethods', filtered[2])
 
         # Check that auth methods data is properly enriched
         user1_methods = next(u for u in filtered if u['objectId'] == 'user1')['c7n:AuthMethods']
         user2_methods = next(u for u in filtered if u['objectId'] == 'user2')['c7n:AuthMethods']
-        user3_methods = next(u for u in filtered if u['objectId'] == 'user3')['c7n:AuthMethods']
 
         self.assertEqual(len(user1_methods), 2)  # User1 has 2 auth methods
         self.assertEqual(len(user2_methods), 1)  # User2 has 1 auth method
-        self.assertEqual(len(user3_methods), 0)  # User3 has no auth methods
 
     def test_last_signin_filter(self):
         """Test last sign-in filter"""


### PR DESCRIPTION
Instead of putting policy logic into a filter, return the data the logic is based on so the logic can be part of a policy.

Fixes https://github.com/sixfeetup/stacklet-entraid/issues/55.

## :new: What is changed by this PR?

Removes the `mfa-enabled` filter on `azure.entraid-user`, and adds the `auth-methods` filter, which just returns the auth methods retrieved by the old filter instead of evaluating them for a particular condition.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
