### PR TITLE
fix: Use uv when running Azure functional tests from the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-functional:
 
 test-functional-azure:
 # note this will provision real resources in Azure's public cloud environment
-	C7N_FUNCTIONAL=yes pytest tools/c7n_azure/tests_azure/tests_resources/test_entraid.py -k terraform -m functional $(ARGS)
+	C7N_FUNCTIONAL=yes uv run pytest tools/c7n_azure/tests_azure/tests_resources/test_entraid.py -k terraform -m functional $(ARGS)
 
 sphinx:
 	make -f docs/Makefile.sphinx html


### PR DESCRIPTION
Fixes https://github.com/sixfeetup/stacklet-entraid/issues/59.
