### PR TITLE
fix: Remove @odata.type as a default field for named locations.

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/entraid_named_locations.py
+++ b/tools/c7n_azure/c7n_azure/resources/entraid_named_locations.py
@@ -69,7 +69,6 @@ class EntraIDNamedLocation(GraphResourceManager):
             'displayName',
             'createdDateTime',
             'modifiedDateTime',
-            '@odata.type',
             'id'
         )
         permissions = ('Policy.Read.All',)


### PR DESCRIPTION
## :dart: What needed to be done and why?

Fixes https://github.com/sixfeetup/stacklet-entraid/issues/69.

Removed `@odata.type` from the list of default fields to report on.  The "@" in the field name is causing the reporting module to fail.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
