### PR TITLE
fix: Handle @ character in field names for CSV reporting

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -135,9 +135,14 @@ def _get_values(record, field_list, tag_map):
             else:
                 value = str(len(value))
         else:
-            value = jmespath_search(field, record)
-            if value is None:
-                value = ''
+            if field.startswith('@'):
+                # Fields starting with @ are JMESPath special characters, use direct access
+                value = record.get(field, '')
+            else:
+                # Use JMESPath for normal field access (supports dot notation, etc.)
+                value = jmespath_search(field, record)
+                if value is None:
+                    value = ''
             if not isinstance(value, str):
                 value = str(value)
         vals.append(value)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,6 +1,6 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
-from c7n.reports.csvout import Formatter, strip_output_path
+from c7n.reports.csvout import Formatter, strip_output_path, _get_values
 from .common import BaseTest, load_data
 
 
@@ -164,3 +164,60 @@ class TestMultiReport(BaseTest):
             strip_output_path(p, policy_name) == f"logs/{policy_name}"
             for p in output_paths
         ))
+
+
+class TestGetValues(BaseTest):
+
+    def test_get_values_with_at_fields(self):
+        """Test _get_values handles fields starting with @ (like @odata.type) correctly."""
+        record = {
+            'id': 'test-id',
+            'displayName': 'Test Location',
+            '@odata.type': '#microsoft.graph.ipNamedLocation',
+            'nested': {'field': 'nested-value'}
+        }
+        tag_map = {}
+
+        # Test @ field extraction
+        fields = ['@odata.type']
+        result = _get_values(record, fields, tag_map)
+        self.assertEqual(result, ['#microsoft.graph.ipNamedLocation'])
+
+        # Test mixed fields (@ field and regular fields)
+        fields = ['id', '@odata.type', 'displayName']
+        result = _get_values(record, fields, tag_map)
+        self.assertEqual(result, ['test-id', '#microsoft.graph.ipNamedLocation', 'Test Location'])
+
+        # Test @ field that doesn't exist in record
+        fields = ['@missing.field']
+        result = _get_values(record, fields, tag_map)
+        self.assertEqual(result, [''])
+
+        # Test normal JMESPath still works
+        fields = ['nested.field']
+        result = _get_values(record, fields, tag_map)
+        self.assertEqual(result, ['nested-value'])
+
+    def test_formatter_with_at_fields(self):
+        """Test Formatter end-to-end with @ fields like @odata.type."""
+        # Create a fake resource type similar to Azure EntraID Named Location
+        class FakeNamedLocationResource:
+            class TypeInfo:
+                id = 'id'
+                name = 'displayName'
+                date = 'createdDateTime'
+                default_report_fields = ('displayName', 'createdDateTime', '@odata.type', 'id')
+
+        formatter = Formatter(resource_type=FakeNamedLocationResource.TypeInfo)
+
+        # Test record with @odata.type field
+        records = [{
+            'id': 'location-1',
+            'displayName': 'Corporate IP Ranges',
+            'createdDateTime': '2023-01-01T00:00:00Z',
+            '@odata.type': '#microsoft.graph.ipNamedLocation'
+        }]
+
+        result = formatter.to_csv(records)
+        expected = [['Corporate IP Ranges', '2023-01-01T00:00:00Z', '#microsoft.graph.ipNamedLocation', 'location-1']]
+        self.assertEqual(result, expected)

--- a/tools/c7n_azure/c7n_azure/resources/entraid_named_locations.py
+++ b/tools/c7n_azure/c7n_azure/resources/entraid_named_locations.py
@@ -69,7 +69,6 @@ class EntraIDNamedLocation(GraphResourceManager):
             'displayName',
             'createdDateTime',
             'modifiedDateTime',
-            '@odata.type',
             'id'
         )
         permissions = ('Policy.Read.All',)

--- a/tools/c7n_azure/c7n_azure/resources/entraid_named_locations.py
+++ b/tools/c7n_azure/c7n_azure/resources/entraid_named_locations.py
@@ -69,6 +69,7 @@ class EntraIDNamedLocation(GraphResourceManager):
             'displayName',
             'createdDateTime',
             'modifiedDateTime',
+            '@odata.type',
             'id'
         )
         permissions = ('Policy.Read.All',)


### PR DESCRIPTION
## :dart: What needed to be done and why?

Fields starting with @ (like @odata.type from Microsoft Graph API) were causing JMESPath parsing errors in the CSV reporting system, since @ is a special character in JMESPath for current node references.

related to https://github.com/stacklet/platform-initial-policies-staging/pull/18

resolves https://github.com/sixfeetup/stacklet-entraid/issues/69

## :new: What is changed by this PR?

- Modified _get_values() in csvout.py to use direct dictionary access for fields starting with @ instead of JMESPath
- Added comprehensive tests for _get_values() and Formatter with @ fields

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
